### PR TITLE
Feature/build docker image

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  # Multi-platform builds need an implicit push, so we trigger only on demand
+  workflow_dispatch: # Trigger only on manual dispatch
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: cli
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/jqa:2.6.0
+          platforms: linux/amd64,linux/arm64

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,9 +1,10 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
-ENV jqa_version=2.0.0-M1
-ENV jqa_cmdline_sha1=e71fe3c201217ed5c479d06e3566ab37cfd781cb
-ENV jqa_distfile_prefix=jqassistant-commandline-distribution
-ENV jqa_distfile_suffix=bin.zip
+#https://repo1.maven.org/maven2/com/buschmais/jqassistant/cli/jqassistant-commandline-neo4jv5/2.6.0/jqassistant-commandline-neo4jv5-2.6.0-distribution.zip
+ENV jqa_version=2.6.0
+ENV jqa_cmdline_sha1=821a5315e1a77223d19f365f9543373ddb294308
+ENV jqa_distfile_prefix=jqassistant-commandline-neo4jv5
+ENV jqa_distfile_suffix=distribution.zip
 
 ENV SERVER="https://repo1.maven.org"
 ENV PATH_SEGMENT="/maven2/com/buschmais/jqassistant/cli/${jqa_distfile_prefix}/${jqa_version}/"
@@ -24,7 +25,7 @@ RUN set -ex; \
 
 RUN set -ex; \
     apt-get install -y --no-install-recommends \
-        openjdk-11-jre
+        openjdk-17-jre
 
 RUN  apt-get clean \
      && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This build [has already worked](https://github.com/ascheman/jqassistant-docker-images/actions/runs/13932058146) and left an image as ghcr.io/ascheman/jqa:2.6.0.
I only had to drop an intermediate commit which made it build on a Git push (usually you only want to build once on the `master` branch).

It includes #5 